### PR TITLE
refactor(formDescription): removed unnescessary formDescription

### DIFF
--- a/src/components/enumber-form.tsx
+++ b/src/components/enumber-form.tsx
@@ -296,11 +296,6 @@ const EnumberForm: FC<EnumberFormProps> = ({ className, veganENumbers }) => {
                   />
                 </label>
               </FormControl>
-              {selectedFileName && !isLoading && (
-                <FormDescription className="md:hidden">
-                  Selected: {selectedFileName}
-                </FormDescription>
-              )}
               {isLoading && (
                 <div className="absolute w-full h-full bg-muted border border-primary rounded-md flex items-center justify-center gap-2">
                   <span className="text-muted-foreground">


### PR DESCRIPTION
removed formDescription of mobile input, because it was too disruptive to the overall design.